### PR TITLE
make anatomical relation an embedded type

### DIFF
--- a/schemas/anatomicalEntity.schema.tpl.json
+++ b/schemas/anatomicalEntity.schema.tpl.json
@@ -26,7 +26,7 @@
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Add one or several relations of this anatomical entity to other anatomical entities that are used elsewhere to describe (roughly) the same anatomical location.",
-      "_linkedTypes": [
+      "_embeddedType": [
         "https://openminds.ebrains.eu/sands/AnatomicalEntityRelation"
       ]
     }


### PR DESCRIPTION
Shouldn't we make the anatomicalrelation an embedded type since it can not live without its anatomical entity?