### PR TITLE
Introduction of lookup labels for schemas with no human readable identifier.

### DIFF
--- a/schemas/atlas/atlasAnnotation.schema.tpl.json
+++ b/schemas/atlas/atlasAnnotation.schema.tpl.json
@@ -53,6 +53,10 @@
         "https://openminds.ebrains.eu/controlledTerms/Laterality"
       ]
     },
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this atlas annotation that may help you to more easily find it again."
+    },
     "name": {
       "type": "string",
       "_instruction": "Enter a descriptive name for this atlas annotation."

--- a/schemas/non-atlas/customAnnotation.schema.tpl.json
+++ b/schemas/non-atlas/customAnnotation.schema.tpl.json
@@ -60,6 +60,10 @@
         "https://openminds.ebrains.eu/controlledTerms/Laterality"
       ]
     },
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this custom annotation that may help you to more easily find it again."
+    },
     "name": {
       "type": "string",
       "_instruction": "Enter a descriptive name for this custom annotation."

--- a/schemas/non-atlas/electrode.schema.tpl.json
+++ b/schemas/non-atlas/electrode.schema.tpl.json
@@ -17,6 +17,10 @@
     "internalIdentifier": {
       "type": "string",
       "_instruction": "Enter the identifier used for this electrode within the file it is stored in."
+    },
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this electrode that may help you to more easily find it again."
     }
   }
 }

--- a/schemas/non-atlas/electrodeArray.schema.tpl.json
+++ b/schemas/non-atlas/electrodeArray.schema.tpl.json
@@ -17,6 +17,10 @@
     "internalIdentifier": {
       "type": "string",
       "_instruction": "Enter the identifier used for this electrode array within the file it is stored in."
+    },
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this electrode array that may help you to more easily find it again."
     }
   }
 }

--- a/schemas/non-atlas/electrodeContact.schema.tpl.json
+++ b/schemas/non-atlas/electrodeContact.schema.tpl.json
@@ -24,6 +24,10 @@
       "type": "string",
       "_instruction": "Enter the identifier used for this electrode contact within the file it is stored in."
     },
+    "lookupLabel": {
+      "type": "string",
+      "_instruction": "Enter a lookup label for this electrode contact that may help you to more easily find it again."
+    },
     "relatedRecording":{
       "type": "array",      
       "minItems": 1,


### PR DESCRIPTION
As discussed this PR introduces optional lookup labels for schemas with no human readable identifier. Cf. PR on openMINDS_core:
https://github.com/HumanBrainProject/openMINDS_core/pull/202