### PR TITLE
Update brainAtlasVersion.schema.tpl.json

### DIFF
--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -19,7 +19,8 @@
     "digitalIdentifier": {
       "_instruction": "Add the globally unique and persistent digital identifier of this brain atlas version.",
       "_linkedTypes": [
-        "https://openminds.ebrains.eu/core/DOI"
+        "https://openminds.ebrains.eu/core/DOI",
+        "https://openminds.ebrains.eu/core/ISBN"
       ]
     },
     "fullName": {


### PR DESCRIPTION
@lzehl, I think we should allow ISBN as digital identifier for brain atlas versions as well. This should be equally commonmore common for older versions. 

What do you think?