### PR TITLE
Some more updates to atlas related schemas

### DIFF
--- a/schemas/atlas/parcellationEntity.schema.tpl.json
+++ b/schemas/atlas/parcellationEntity.schema.tpl.json
@@ -8,8 +8,11 @@
     "hasVersion"  
   ],
   "properties": {
-    "hasParent": {
-      "_instruction": "Add for this parcellation entity the defined anatomical parent structure.",
+    "hasParent": {      
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the defined anatomical parent structure for this parcellation entity or several if required.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/ParcellationEntity"
       ]

--- a/schemas/atlas/parcellationEntity.schema.tpl.json
+++ b/schemas/atlas/parcellationEntity.schema.tpl.json
@@ -12,7 +12,7 @@
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add the defined anatomical parent structure for this parcellation entity or several if required.",
+      "_instruction": "Add the defined anatomical parent structure for this parcellation entity, or several if required.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/ParcellationEntity"
       ]

--- a/schemas/atlas/parcellationEntityVersion.schema.tpl.json
+++ b/schemas/atlas/parcellationEntityVersion.schema.tpl.json
@@ -12,9 +12,12 @@
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/sands/AtlasAnnotation"
       ]
-    },
-    "hasParent": {
-      "_instruction": "Add for this parcellation entity version the defined anatomical parent structure (version).",
+    },    
+    "hasParent": {      
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add the defined anatomical parent structure (version) for this parcellation entity version, or several if required.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/ParcellationEntity",       
         "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"

--- a/schemas/atlas/parcellationTerminologyVersion.schema.tpl.json
+++ b/schemas/atlas/parcellationTerminologyVersion.schema.tpl.json
@@ -1,6 +1,7 @@
 {
   "_type": "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion",
   "required": [
+    "hasEntityVersion",
     "shortName",    
     "versionIdentifier",
     "versionInnovation"


### PR DESCRIPTION
ParcellationTerminologyVersion: "hasEntityVersion" changed to required (as it is for ParecllationTerminology and should be)
ParcellationEntity & ParcellationEntityVersion: "hasParent" changed to array (0 - N) to accommodate for cases where a single entity is not enough to describe the relationship. Example from Waxholm atlas: Both, v1.01 and v3, have "hippocampal formation". For v1.01 the parent is "Cerebral cortex incl. neocortex & hippocampus", but for v3 the parent is "Cortical plate". The ParcellationEntities for the ParcellationTerminology for the Waxholm atlas would contain all 3 terms, but "hippocampal formation" would need to have two parents - "Cerebral cortex incl. neocortex & hippocampus" and "Cortical plate". 