### PR TITLE
PE "hasVersion" optional

### DIFF
--- a/schemas/atlas/parcellationEntity.schema.tpl.json
+++ b/schemas/atlas/parcellationEntity.schema.tpl.json
@@ -4,8 +4,7 @@
     "studyTarget"
   ],
   "required": [
-    "name",
-    "hasVersion"  
+    "name"
   ],
   "properties": {
     "hasParent": {      


### PR DESCRIPTION
With the change to only having annotated regions as PEVs and regions used to produce a hierarchy (but aren't actually annotated themselves), we need to make "hasVersion" optional. 
