### PR TITLE
fixing at-type error and at-id error

### DIFF
--- a/instances/atlas/brainAtlas/AALAtlas1.jsonld
+++ b/instances/atlas/brainAtlas/AALAtlas1.jsonld
@@ -1,0 +1,222 @@
+{
+    "@context": {
+        "@vocab": "https://openminds.ebrains.eu/vocab/"
+    },
+    "@id": "https://openminds.ebrains.eu/instances/brainAtlas/AAL1",
+    "@type": "https://openminds.ebrains.eu/sands/BrainAtlas",
+    "abbreviation": "AAL1"
+    "author": null,
+    "custodian": null,
+    "description": null,
+    "digitalIdentifier": null,
+    "fullName": "Automated Anatomical Labeling Atlas 1",
+    "hasTerminology": {
+		"@type": "https://openminds.ebrains.eu/sands/ParcellationTerminology",
+		"definedIn": null,
+		"hasEntity": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_centralRegion"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PRE"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_POST"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_RO"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_frontalLobe"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_frontalLobeLateralSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F1"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F2"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F3OP"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F3T"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_frontalLobeMedialSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F1M"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_SMA"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PCL"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_frontalLobeOrbitalSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F1O"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F1MO"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F2O"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_F3O"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_GR"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_OC"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_temporalLobe"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_temporalLobeLateralSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_T1"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_HES"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_T2"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_T3"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_parietalLobe"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_parietalLobeLateralSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_P1"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_P2"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_AG"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_SMG"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_parietalLobeMedialSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PQ"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_occipitalLobe"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_occipitalLobeLateralSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_O1"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_O2"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_O3"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_occipitalLobeMedialAndInferiorSurface"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_Q"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_V1"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_LING"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_FUSI"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_limbicLobe"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_T1P"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_T2P"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_ACIN"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_MCIN"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PCIN"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_HIP"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PHIP"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_IN"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_sub-corticalGrayNuclei"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_AMYG"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_CAU"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PUT"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_PAL"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntity/AAL1_THA"
+			}
+		],
+		"ontologyIdentifier": null
+	},
+    "hasVersion": [
+        {
+            "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM12_v0"
+        },
+        {
+            "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM8_v0"
+        },
+        {
+            "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM5_v0"
+        },
+        {
+            "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM2_v0"
+        },
+        {
+            "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM99_v0"
+        }
+    ],
+    "homepage": {
+        "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL_homepage"
+    },
+    "howToCite": null,
+    "shortName": "AAL Atlas 1"
+}

--- a/instances/atlas/brainAtlasVersion/AAL1_SPM12_v0.jsonld
+++ b/instances/atlas/brainAtlasVersion/AAL1_SPM12_v0.jsonld
@@ -1,0 +1,319 @@
+{
+    "@context": {
+        "@vocab": "https://openminds.ebrains.eu/vocab/"
+    },
+    "@id": "https://openminds.ebrains.eu/instances/brainAtlasVersion/AAL1_SPM12_2018",
+    "@type": "https://openminds.ebrains.eu/sands/BrainAtlasVersion",
+    "abbreviation": "AAL1",
+    "accessibility": {
+        "@id": "https://openminds.ebrains.eu/instances/productAccessibility/freeAccess"
+    },
+    "atlasType": {
+        "@id": "https://openminds.ebrains.eu/instances/atlasType/deterministicAtlas"
+    },
+    "author": null,
+    "coordinateSpace": {
+        "@id": "https://openminds.ebrains.eu/instances/commonCoordinateSpace/Colin27_2008"
+    },
+    "copyright": null,
+    "custodian": null,
+    "description": "The AAL1 atlas comprises an anatomical parcellation of the spatially normalized single-subject high-resolution T1 volume (Colin27, 2008) provided by the Montreal Neurological Institute (MNI) which can be used to automatically label individual subject brains of functional studies. The MNI single-subjectmain sulci were first delineated and further used as landmarks for the 3D definition of 45 anatomical volumes of interest (AVOI) in each hemisphere. This procedure was performed using a dedicated software which allowed a 3D following of the sulci course on the edited brain. Regions of interest were then drawn manually with the same software every 2mm on the axial slices of the high-resolution MNI single subject. The 90 AVOI were reconstructed and assigned a label. For automated anatomical labelling of functional studies according to this parcellation method, three procedures are proposed: (1) labelling of an extremum defined by a set of coordinates; (2) percentage of voxels belonging to teach of the AVOI intersected by a sphere centered by a set of coordinates; (3) percentage of voxels belonging to each of the AVOI intersected by an activated cluster. An interface with the Statistical Parametric Mapping (SPM) packages is provided as a freeware to researchers of the neuroimaging community to conduct the automated labelling procedures.",
+    "digitalIdentifier": null,
+    "fullDocumentation": null,
+    "fullName": "Automated Anatomical Labeling Atlas 1",
+    "funding": null,
+    "hasTerminologyVersion": {
+		"@type": "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion",
+		"definedIn": null,
+		"hasEntityVersion": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PRE_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_POST_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_RO_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F2_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3OP_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3T_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1M_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_SMA_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PCL_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1O_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1MO_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F2O_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3O_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_GR_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_OC_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T1_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_HES_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T2_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T3_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_P1_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_P2_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_AG_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_SMG_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PQ_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O1_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O2_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O3_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_Q_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_V1_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_LING_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_FUSI_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T1P_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T2P_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_ACIN_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_MCIN_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PCIN_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_HIP_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PHIP_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_IN_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_AMYG_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_CAU_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PUT_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PAL_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_THA_left"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PRE_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_POST_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_RO_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F2_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3OP_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3T_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1M_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_SMA_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PCL_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1O_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F1MO_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F2O_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_F3O_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_GR_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_OC_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T1_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_HES_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T2_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T3_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_P1_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_P2_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_AG_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_SMG_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PQ_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O1_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O2_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_O3_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_Q_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_V1_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_LING_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_FUSI_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T1P_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_T2P_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_ACIN_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_MCIN_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PCIN_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_HIP_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PHIP_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_IN_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_AMYG_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_CAU_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PUT_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_PAL_right"
+			},
+			{
+				"@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/AAL1_SPM12_2018_THA_right"
+			}
+		],
+		"ontologyIdentifier": null
+	},
+    "homepage": null,
+    "howToCite": null,
+    "isAlternativeVersionOf": null,
+    "isNewVersionOf": null,
+    "keyword": null,
+    "license": {
+        "@id": "https://openminds.ebrains.eu/instances/licenses/ccByNcNd4.0"
+    },
+    "ontologyIdentifier": null,
+    "otherContribution": null,
+    "relatedPublication": null,
+    "releaseDate": "",
+    "repository": null,
+    "shortName": "AAL Atlas 1",
+    "supportChannel": null,
+    "versionIdentifier": "SPM12, 2018",
+    "versionInnovation": "This is the 2018 release of the SPM12 version of the AAL Atlas 1 containing 3D definitions of 45 anatomical volumes of interest in each hemisphere."
+}

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-1_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-1_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-1_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-1_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-1_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-1_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-1_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-1_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-1_PM-v10.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-1_PM-v12.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-2_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-2_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-2_PM-v7.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-25.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-25.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-25_PM-v16.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-25_PM-v16.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-25_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-25_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-25_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-25_PM-v18.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-25_PM-v20.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-33.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-33.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-33_PM-v16.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-33_PM-v16.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-33_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-33_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-33_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-33_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-33_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-33_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v16.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-33_PM-v20.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-3a.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-3a.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-3a_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-3a_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-3a_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-3a_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-3a_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-3a_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3a_PM-v10.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-3a_PM-v12.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-3b.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-3b.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-3b_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-3b_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-3b_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-3b_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-3b_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-3b_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-3b_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-3b_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-3b_PM-v8.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-3b_PM-v12.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-44.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-44.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-44_PM-v7.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-44_PM-v7.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-44_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-44_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-44_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-44_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-44_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-44_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-44_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-44_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-44_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-45.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-45.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-45_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-45_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-45_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-45_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-45_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-45_PM-v7.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-45_PM-v7.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-45_PM-v7.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-45_PM-v7.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-45_PM-v7.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-45_PM-v7.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-45_PM-v9.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-4a.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-4a.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-4a_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-4a_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-4a_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-4a_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4a_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-4a_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-4a_PM-v11.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-4a_PM-v13.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-4p.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-4p.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-4p_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-4p_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-4p_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-4p_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-4p_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-4p_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-4p_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-4p_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-4p_PM-v9.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-4p_PM-v13.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-5Ci.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-5Ci.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-5Ci_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-5Ci_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5Ci_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5Ci_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5Ci_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5Ci_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5Ci_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5Ci_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5Ci_PM-v9.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-5Ci_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-5L.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-5L.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5L_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-5L_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-5L_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5L_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5L_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5L_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5L_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5L_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v8.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-5L_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-5M.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-5M.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5M_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-5M_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-5M_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-5M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-5M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-5M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-5M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-5M_PM-v8.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-5M_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-6d1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-6d1.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d1_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d1_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v5.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-6d1_PM-v7.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-6d2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-6d2.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d2_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d2_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d2_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d2_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-6d2_PM-v7.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-6d3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-6d3.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d3_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d3_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6d3_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6d3_PM-v4.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6d3_PM-v4.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6d3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6d3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6d3_PM-v4.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-6d3_PM-v7.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-6ma.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-6ma.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6ma_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6ma_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6ma_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6ma_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6ma_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6ma_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6ma_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6ma_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6ma_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6ma_PM-v9.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-6ma_PM-v12.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-6mp.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-6mp.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6mp_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6mp_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6mp_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-6mp_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-6mp_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-6mp_PM-v9.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-6mp_PM-v9.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-6mp_PM-v12.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-7A.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-7A.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7A_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7A_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7A_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7A_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-7A_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-7A_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7A_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7A_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7A_PM-v8.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-7A_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-7M.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-7M.jsonld
@@ -11,37 +11,37 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-7M_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-7M_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7M_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7M_PM-v9.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-7M_PM-v9.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-7P.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-7P.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7P_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7P_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7P_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7P_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7P_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7P_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7P_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7P_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-7P_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-7P_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v8.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-7P_PM-v9.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-7PC.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-7PC.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7PC_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7PC_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7PC_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-7PC_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-7PC_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-7PC_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-7PC_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-7PC_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-7PC_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-7PC_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v8.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-7PC_PM-v9.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-FG1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-FG1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-FG1_PM-v1.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-FG1_PM-v1.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG1_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG1_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG1_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG1_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG1_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG1_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG1_PM-v1.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-FG1_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-FG2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-FG2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG2_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG2_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG2_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG2_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-FG2_PM-v1.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-FG2_PM-v1.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG2_PM-v1.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG2_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG2_PM-v1.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG2_PM-v1.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-FG2_PM-v3.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-FG3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-FG3.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG3_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG3_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-FG3_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-FG3_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG3_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG3_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-FG3_PM-v7.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-FG4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-FG4.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG4_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG4_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-FG4_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-FG4_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-FG4_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-FG4_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG4_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG4_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-FG4_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-FG4_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v6.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-FG4_PM-v7.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Fo1_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Fo1_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo1_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo1_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo1_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo1_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo1_PM-v5.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo1_PM-v5.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Fo2_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Fo2_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo2_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo2_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo2_PM-v3.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fo2_PM-v5.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo3.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo3_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo3_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo3_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Fo3_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Fo3_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo3_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo3_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo3_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo3_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo3_PM-v5.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fo3_PM-v5.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo4.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo4_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo4_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo4_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo4_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo4_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo4_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo4_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo4_PM-v2.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fo4_PM-v3.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo5.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo5.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo5_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo5_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo5_PM-v2.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fo5_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo6.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo6.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo6_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo6_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo6_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo6_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo6_PM-v2.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fo6_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo7.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fo7.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo7_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fo7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fo7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fo7_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v2.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fo7_PM-v2.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fo7_PM-v2.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Fo7_PM-v3.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fp1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fp1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fp1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fp1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fp1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fp1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fp1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fp1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fp1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fp1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Fp1_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Fp1_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp1_PM-v2.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Fp1_PM-v5.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Fp2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Fp2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fp2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fp2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Fp2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Fp2_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Fp2_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Fp2_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Fp2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Fp2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v4.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Fp2_PM-v5.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Ia.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Ia.jsonld
@@ -7,58 +7,58 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ia_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ia_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ia_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ia_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ia_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ia_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ia_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ia_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ia_PM-v3.1_left"
         }
     ],
     "lookupLabel": "JBA_Area-Ia",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Id1_PM-v11.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Id1_PM-v11.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v13.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Id1_PM-v14.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id2.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id2_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id2_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id2_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id2_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id2_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id2_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id2_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Id2_PM-v9.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id3.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id3_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id3_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id3_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id3_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id3_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id3_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id3_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id3_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id3_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Id3_PM-v9.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id4.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id4_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id4_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id4_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id4_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id4_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id4_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v3.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Id4_PM-v5.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id5.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id5.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id5_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id5_PM-v4.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Id5_PM-v5.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id6.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id6.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id6_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id6_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id6_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id6_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id6_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id6_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id6_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id6_PM-v3.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Id6_PM-v5.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Id7.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Id7.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id7_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id7_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Id7_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Id7_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Id7_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Id7_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Id7_PM-v7.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-Id7_PM-v8.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Ig1_PM-v11.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Ig1_PM-v11.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig1_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig1_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v13.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig1_PM-v14.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-Ig2_PM-v11.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-Ig2_PM-v11.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig2_PM-v13.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig2_PM-v13.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig2_PM-v14.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig2_PM-v14.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v13.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig2_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig2_PM-v14.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig2_PM-v14.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-Ig3.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig3_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig3_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-Ig3_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-Ig3_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-Ig3_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-Ig3_PM-v4.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-Ig3_PM-v5.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP1_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP1_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP1_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP1_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-OP1_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-OP1_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP1_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP1_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP1_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP1_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP1_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP1_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP1_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP1_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP1_PM-v12.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP1_PM-v12.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP2_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP2_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP2_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP2_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP2_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP2_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-OP2_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-OP2_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP2_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP2_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP2_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP2_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP2_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP2_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP2_PM-v11.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP2_PM-v12.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP3.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP3_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP3_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-OP3_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-OP3_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP3_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP3_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP3_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP3_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP3_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP3_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP3_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP3_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP3_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP3_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP3_PM-v12.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP3_PM-v12.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP4.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP4_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP4_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-OP4_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-OP4_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP4_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP4_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP4_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP4_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP4_PM-v12.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP4_PM-v12.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP4_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP4_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP4_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP4_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v12.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP4_PM-v11.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP4_PM-v12.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP5.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP5.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP5_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP5_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP5_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP5_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP5_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP5_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP5_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP5_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP5_PM-v2.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP5_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP6.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP6.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP6_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP6_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP6_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP6_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP6_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP6_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP6_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP6_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP6_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP6_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP6_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP6_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP6_PM-v3.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP6_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP7.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP7.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP7_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP7_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP7_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP7_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP7_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP7_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP7_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP7_PM-v2.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP7_PM-v2.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP7_PM-v3.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP7_PM-v3.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP8.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP8.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP8_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP8_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP8_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP8_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP8_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP8_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP8_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP8_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP8_PM-v5.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP8_PM-v6.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-OP9.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-OP9.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP9_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP9_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-OP9_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-OP9_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-OP9_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-OP9_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-OP9_PM-v6.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-OP9_PM-v6.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PF.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PF.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PF_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PF_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PF_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PF_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PF_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PF_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PF_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PF_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v9.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-PF_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PFcm.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PFcm.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFcm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFcm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFcm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFcm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFcm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PFcm_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PFcm_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFcm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFcm_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFcm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFcm_PM-v9.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-PFcm_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PFm.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PFm.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFm_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFm_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFm_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PFm_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PFm_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFm_PM-v11.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-PFm_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PFop.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PFop.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PFop_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PFop_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFop_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFop_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFop_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFop_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFop_PM-v11.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-PFop_PM-v11.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PFt.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PFt.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFt_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFt_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFt_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PFt_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PFt_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFt_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PFt_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PFt_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PFt_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PFt_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PFt_PM-v9.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-PFt_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PGa.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PGa.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PGa_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PGa_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PGa_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PGa_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PGa_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PGa_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PGa_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PGa_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PGa_PM-v9.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-PGa_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-PGp.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-PGp.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-PGp_PM-v9.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-PGp_PM-v9.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PGp_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PGp_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-PGp_PM-v9.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-PGp_PM-v9.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v9.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-PGp_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-PGp_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-PGp_PM-v11.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-STS1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-STS1.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-STS1_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-STS1_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-STS1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-STS1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-STS1_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-STS1_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v3.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-STS1_PM-v5.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-STS2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-STS2.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-STS2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-STS2_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-STS2_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-STS2_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v3.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-STS2_PM-v5.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-TE-3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-TE-3.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TE-3_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TE-3_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TE-3_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TE-3_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-TE-3_PM-v5.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-TE-3_PM-v5.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TE-3_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TE-3_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-TE-3_PM-v6.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-TI.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-TI.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TI_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TI_PM-v5.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-TI_PM-v6.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-TeI.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-TeI.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TeI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TeI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TeI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TeI_PM-v6.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TeI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TeI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-TeI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-TeI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-TeI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-TeI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-TeI_PM-v5.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-TeI_PM-v5.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v5.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-TeI_PM-v6.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-TeI_PM-v6.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-a29.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-a29.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-a29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-a29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-a29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-a29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-a29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-a29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-a29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-a29_PM-v11.0_right"
         }
     ],
     "lookupLabel": "JBA_Area-a29",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-a30.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-a30.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-a30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-a30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-a30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-a30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-a30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-a30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-a30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-a30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-a30_PM-v11.0_right"
         }
     ],
     "lookupLabel": "JBA_Area-a30",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP1_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP1_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hIP1_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hIP1_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP1_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP1_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP1_PM-v7.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hIP2_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hIP2_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP2_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP2_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v7.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP2_PM-v6.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP2_PM-v7.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP2_PM-v7.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hIP2_PM-v7.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP3.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hIP3_PM-v8.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hIP3_PM-v8.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP3_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP3_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP3_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP3_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP3_PM-v8.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP3_PM-v8.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP3_PM-v8.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP3_PM-v8.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP3_PM-v9.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hIP3_PM-v9.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP4.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP4_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP4_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP4_PM-v7.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP5.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP5.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP5_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP5_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP5_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP5_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP5_PM-v7.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP6.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP6.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP6_PM-v7.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP7.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP7.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP7_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP7_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP7_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP7_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hIP7_PM-v7.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP8.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hIP8.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hIP8_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hIP8_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hIP8_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hIP8_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hIP8_PM-v7.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc1.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc1_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc1_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hOc1_PM-v4.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc2.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc2_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc2_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc2_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc2_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc2_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc2_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc2_PM-v2.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hOc2_PM-v4.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc3d.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc3d.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc3d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc3d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc3d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc3d_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc3d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc3d_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc3d_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc3d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v2.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3d_PM-v4.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc3v.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc3v.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc3v_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc3v_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc3v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc3v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc3v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc3v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc3v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc3v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v3.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc3v_PM-v5.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4d.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4d.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc4d_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc4d_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4d_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4d_PM-v4.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4la.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4la.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4la_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4la_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4la_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4la_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4la_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc4la_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc4la_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4la_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v3.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4la_PM-v5.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4lp.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4lp.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc4lp_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc4lp_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4lp_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4lp_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4lp_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4lp_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4lp_PM-v5.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4v.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc4v.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc4v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc4v_PM-v5.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc4v_PM-v5.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc4v_PM-v3.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc4v_PM-v3.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v3.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc4v_PM-v5.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc5.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc5.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc5_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc5_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-hOc5_PM-v2.2"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-hOc5_PM-v2.2"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc5_PM-v4.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc5_PM-v4.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc5_PM-v4.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc5_PM-v2.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc5_PM-v2.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hOc5_PM-v4.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc6.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hOc6.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hOc6_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc6_PM-v7.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-hPO1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-hPO1.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hPO1_PM-v7.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hPO1_PM-v7.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-i29.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-i29.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-i29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-i29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-i29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-i29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-i29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-i29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-i29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-i29_PM-v11.0_right"
         }
     ],
     "lookupLabel": "JBA_Area-i29",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-i30.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-i30.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-i30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-i30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-i30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-i30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-i30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-i30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-i30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-i30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-i30_PM-v11.0_left"
         }
     ],
     "lookupLabel": "JBA_Area-i30",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-p24ab.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-p24ab.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p24ab_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p24ab_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p24ab_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p24ab_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p24ab_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p24ab_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24ab_PM-v16.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-p24ab_PM-v20.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-p24c.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-p24c.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p24c_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p24c_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p24c_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p24c_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p24c_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p24c_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p24c_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p24c_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p24c_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p24c_PM-v16.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-p24c_PM-v20.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-p29.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-p29.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p29_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p29_PM-v11.0_left"
         }
     ],
     "lookupLabel": "JBA_Area-p29",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-p30.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-p30.jsonld
@@ -7,28 +7,28 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p30_PM-v11.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p30_PM-v11.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p30_PM-v11.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p30_PM-v11.0_right"
         }
     ],
     "lookupLabel": "JBA_Area-p30",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-p32.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-p32.jsonld
@@ -11,58 +11,58 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-p32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-p32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-p32_PM-v20.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-s24.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-s24.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-s24_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-s24_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-s24_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-s24_PM-v16.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-s24_PM-v16.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-s24_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-s24_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-s24_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-s24_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-s24_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s24_PM-v16.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-s24_PM-v20.1_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Area-s32.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Area-s32.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-s32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-s32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-s32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Area-s32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Area-s32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Area-s32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Area-s32_PM-v16.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Area-s32_PM-v16.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v18.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Area-s32_PM-v16.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Area-s32_PM-v16.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v16.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-s32_PM-v20.1_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_CA.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_CA.jsonld
@@ -7,16 +7,16 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_CA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_CA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CA_PM-v11.1_left"
         }
     ],
     "lookupLabel": "JBA_CA",

--- a/instances/atlas/parcellationEntity/JBA/JBA_CA1.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_CA1.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA1_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA1_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA1_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA1_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA1_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA1_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA1_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA1_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA1_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA1_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA1_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA1_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v11.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_CA1_PM-v13.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_CA2.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_CA2.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA2_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA2_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA2_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA2_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA2_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA2_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA2_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA2_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA2_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA2_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA2_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA2_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_CA2_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_CA3.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_CA3.jsonld
@@ -11,46 +11,46 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA3_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA3_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA3_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA3_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA3_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA3_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CA3_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CA3_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CA3_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CA3_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CA3_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CA3_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CA3_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_CA3_PM-v13.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_CM.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_CM.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_CM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_CM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_CM_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_CM_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_CM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_CM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_CM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CM_PM-v6.4_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_CM_PM-v8.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Ch-123.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Ch-123.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Ch-123_PM-v4.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Ch-123_PM-v4.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ch-123_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ch-123_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ch-123_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ch-123_PM-v4.2_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Ch-123_PM-v4.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Ch-4.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Ch-4.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Ch-4_PM-v4.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Ch-4_PM-v4.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.2_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Ch-4_PM-v4.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_DG.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_DG.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_DG_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_DG_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_DG_PM-v11b.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_DG_PM-v11b.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_DG_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_DG_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_DG_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_DG_PM-v13.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Dorsal-Dentate-Nucleus.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Dorsal-Dentate-Nucleus.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Dorsal-Dentate-Nucleus_PM-v6.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Entorhinal-Cortex.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Entorhinal-Cortex.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Entorhinal-Cortex_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Entorhinal-Cortex_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Entorhinal-Cortex_PM-v11b.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Entorhinal-Cortex_PM-v11b.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Entorhinal-Cortex_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Entorhinal-Cortex_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Entorhinal-Cortex_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Fastigial-Nucleus.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Fastigial-Nucleus.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Fastigial-Nucleus_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Fastigial-Nucleus_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Fastigial-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Fastigial-Nucleus_PM-v6.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Frontal-I.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Frontal-I.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-I_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-I_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-I_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-I_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-I_PM-v10.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Frontal-I_PM-v11.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Frontal-II.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Frontal-II.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-II_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-II_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-II_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-II_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-II_PM-v10.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Frontal-II_PM-v11.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Frontal-to-Occipital.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Frontal-to-Occipital.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-to-Occipital_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-to-Occipital_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-to-Occipital_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-to-Occipital_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v10.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Occipital_PM-v11.3_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Frontal-to-Temporal.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Frontal-to-Temporal.jsonld
@@ -7,22 +7,22 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-to-Temporal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-to-Temporal_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Frontal-to-Temporal_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Frontal-to-Temporal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Frontal-to-Temporal_PM-v10.0_right"
         }
     ],
     "lookupLabel": "JBA_Frontal-to-Temporal",

--- a/instances/atlas/parcellationEntity/JBA/JBA_HATA.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HATA.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HATA_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HATA_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HATA_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HATA_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_HATA_PM-v11b.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_HATA_PM-v11b.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_HATA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_HATA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_HATA_PM-v11.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_HATA_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_HC-Parasubiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HC-Parasubiculum.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Parasubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Parasubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Parasubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Parasubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Parasubiculum_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_HC-Parasubiculum_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_HC-Presubiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HC-Presubiculum.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Presubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Presubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Presubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Presubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_HC-Presubiculum_PM-v13.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_HC-Prosubiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HC-Prosubiculum.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Prosubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Prosubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Prosubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Prosubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_HC-Prosubiculum_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_HC-Subiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HC-Subiculum.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Subiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Subiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Subiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Subiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Subiculum_PM-v13.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_HC-Subiculum_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_HC-Transsubiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_HC-Transsubiculum.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Transsubiculum_PM-v13.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Transsubiculum_PM-v13.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_HC-Transsubiculum_PM-v13.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_HC-Transsubiculum_PM-v13.0_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_HC-Transsubiculum_PM-v13.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_IF.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_IF.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_IF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_IF_PM-v8.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_IF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_IF_PM-v8.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_IF_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_IF_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_IF_PM-v8.1_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_IF_PM-v8.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Interposed-Nucleus.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Interposed-Nucleus.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Interposed-Nucleus_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Interposed-Nucleus_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.2_right"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Interposed-Nucleus_PM-v6.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_LB.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_LB.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_LB_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_LB_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_LB_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_LB_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_LB_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_LB_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_LB_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_LB_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_LB_PM-v8.2_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_MF.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_MF.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_MF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_MF_PM-v8.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_MF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_MF_PM-v8.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_MF_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_MF_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.1_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_MF_PM-v8.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_SF.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_SF.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_SF_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_SF_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_SF_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_SF_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_SF_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_SF_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_SF_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_SF_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_SF_PM-v8.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_SF_PM-v8.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Subiculum.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Subiculum.jsonld
@@ -7,43 +7,43 @@
     "hasParent": null,
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Subiculum_PM-v11b.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Subiculum_PM-v11b.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Subiculum_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Subiculum_PM-v11.1_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Subiculum_PM-v11.1_right"
         }
     ],
     "lookupLabel": "JBA_Subiculum",

--- a/instances/atlas/parcellationEntity/JBA/JBA_Temporal-to-Parietal.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Temporal-to-Parietal.jsonld
@@ -11,22 +11,22 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Temporal-to-Parietal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Temporal-to-Parietal_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Temporal-to-Parietal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Temporal-to-Parietal_PM-v10.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Temporal-to-Parietal_PM-v10.0_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Temporal-to-Parietal_PM-v11.3_left"

--- a/instances/atlas/parcellationEntity/JBA/JBA_VTM.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_VTM.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_VTM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_VTM_PM-v8.0_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_VTM_PM-v8.0_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_VTM_PM-v6.4_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_VTM_PM-v6.4_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_VTM_PM-v8.0_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_VTM_PM-v8.0_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_VTM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_VTM_PM-v6.1"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_VTM_PM-v6.1"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_VTM_PM-v6.4_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_VTM_PM-v8.2_right"

--- a/instances/atlas/parcellationEntity/JBA/JBA_Ventral-Dentate-Nucleus.jsonld
+++ b/instances/atlas/parcellationEntity/JBA/JBA_Ventral-Dentate-Nucleus.jsonld
@@ -11,61 +11,61 @@
     ],
     "hasVersion": [
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.13_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.0"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.13_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.0"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.2_right"
         },
         {
-            "@id": "https://openminds.ebrains.eu/instances/JBA-v2.5_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
+            "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.5_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
         },
         {
             "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Ventral-Dentate-Nucleus_PM-v6.3_left"

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-1_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-1_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-1_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-1_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-1_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-25_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-25_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-25_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-25_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-25_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-2_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-2_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-2_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-2_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-2_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-33_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-33_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-33_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-33_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-33_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3a_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3a_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3a_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3a_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3a_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3b_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3b_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3b_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-3b_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-3b_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-44_PM-v7-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-44_PM-v7-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-44_PM-v7-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-44_PM-v7-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-44_PM-v7.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-45_PM-v7-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-45_PM-v7-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-45_PM-v7-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-45_PM-v7-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-45_PM-v7.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4a_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4a_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4a_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4a_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4a_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4p_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4p_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4p_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-4p_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-4p_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5Ci_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5Ci_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5Ci_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5Ci_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5Ci_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5L_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5L_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5L_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5L_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5L_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5M_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5M_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5M_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-5M_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-5M_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d1_PM-v4-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d1_PM-v4-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d1_PM-v4-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d1_PM-v4-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d1_PM-v4.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d2_PM-v4-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d2_PM-v4-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d2_PM-v4-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d2_PM-v4-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d2_PM-v4.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d3_PM-v4-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6d3_PM-v4-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6d3_PM-v4.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6ma_PM-v9-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6ma_PM-v9-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6ma_PM-v9.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6mp_PM-v9-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-6mp_PM-v9-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-6mp_PM-v9.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7A_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7A_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7A_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7A_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7A_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7M_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7M_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7M_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7M_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7M_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7PC_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7PC_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7PC_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7PC_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7PC_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7P_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7P_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7P_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-7P_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-7P_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG1_PM-v1-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG1_PM-v1-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG1_PM-v1-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG1_PM-v1-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG1_PM-v1.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG2_PM-v1-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG2_PM-v1-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG2_PM-v1-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG2_PM-v1-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG2_PM-v1.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG3_PM-v6-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG3_PM-v6-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG3_PM-v6-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG3_PM-v6-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG3_PM-v6.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG4_PM-v6-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG4_PM-v6-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG4_PM-v6-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-FG4_PM-v6-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-FG4_PM-v6.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo1_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo1_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo1_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo1_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo1_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo2_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo2_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo2_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo2_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo2_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo3_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo3_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo3_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo3_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo3_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo4_PM-v2-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo4_PM-v2-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo4_PM-v2-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo4_PM-v2-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo4_PM-v2.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo5_PM-v2-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo5_PM-v2-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo5_PM-v2-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo5_PM-v2-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo5_PM-v2.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo6_PM-v2-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo6_PM-v2-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo6_PM-v2-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo6_PM-v2-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo6_PM-v2.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo7_PM-v2-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo7_PM-v2-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo7_PM-v2-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fo7_PM-v2-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fo7_PM-v2.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp1_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp1_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp1_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp1_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp1_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp2_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp2_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp2_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Fp2_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Fp2_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ia_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ia_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ia_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id1_PM-v13-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id1_PM-v13-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id1_PM-v13-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id1_PM-v13-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id1_PM-v13.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id4_PM-v3-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id4_PM-v3-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id4_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id4_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id4_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id5_PM-v3-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id5_PM-v3-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id5_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id5_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id5_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id6_PM-v3-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id6_PM-v3-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id6_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id6_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id6_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id7_PM-v6-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Id7_PM-v6-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Id7_PM-v6.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig1_PM-v13-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig1_PM-v13-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig1_PM-v13-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig1_PM-v13-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig1_PM-v13.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig2_PM-v13-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig2_PM-v13-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig2_PM-v13-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-Ig2_PM-v13-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-Ig2_PM-v13.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP1_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP1_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP1_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP1_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP1_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP2_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP2_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP2_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP2_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP2_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP3_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP3_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP3_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP3_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP3_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP4_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP4_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP4_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP4_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP4_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP8_PM-v5-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP8_PM-v5-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP8_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP8_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP8_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP9_PM-v5-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP9_PM-v5-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP9_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-OP9_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-OP9_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PF_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PF_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PF_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PF_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PF_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFcm_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFcm_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFcm_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFcm_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFcm_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFm_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFm_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFm_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFm_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFm_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFop_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFop_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFop_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFop_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFop_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFt_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFt_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFt_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PFt_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PFt_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGa_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGa_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGa_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGa_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGa_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGp_PM-v9-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGp_PM-v9-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGp_PM-v9-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-PGp_PM-v9-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-PGp_PM-v9.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS1_PM-v3-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS1_PM-v3-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS1_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS1_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS1_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS2_PM-v3-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS2_PM-v3-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS2_PM-v3-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-STS2_PM-v3-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-STS2_PM-v3.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-0_PM-v5-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-0_PM-v5-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.0_PM-v5.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.0_PM-v5.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-0_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-0_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.0_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.0_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-1_PM-v5-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-1_PM-v5-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.1_PM-v5.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.1_PM-v5.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-1_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-1_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.1_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.1_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-2_PM-v5-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-2_PM-v5-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.2_PM-v5.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.2_PM-v5.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-2_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-1-2_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-1.2_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-1.2_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-3_PM-v5-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-TE-3_PM-v5-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-TE-3_PM-v5.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP1_PM-v6-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP1_PM-v6-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP1_PM-v6-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP1_PM-v6-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP1_PM-v6.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP2_PM-v6-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP2_PM-v6-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP2_PM-v6-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP2_PM-v6-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP2_PM-v6.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP3_PM-v8-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP3_PM-v8-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP3_PM-v8-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP3_PM-v8-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP3_PM-v8.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP4_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP4_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP4_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP4_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP4_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP5_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP5_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP5_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP5_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP5_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP6_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP6_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP6_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP6_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP6_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP7_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP7_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP7_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP7_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP7_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP8_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP8_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP8_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hIP8_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hIP8_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc2_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc2_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc2_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc2_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc2_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3d_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3d_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3d_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3d_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3d_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3v_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3v_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3v_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc3v_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc3v_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4d_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4d_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4d_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4d_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4d_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4la_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4la_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4la_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4la_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4la_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4lp_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4lp_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4lp_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4lp_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4lp_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4v_PM-v3-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4v_PM-v3-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4v_PM-v3-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc4v_PM-v3-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc4v_PM-v3.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc5_PM-v2-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc5_PM-v2-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc5_PM-v2-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc5_PM-v2-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc5_PM-v2.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc6_PM-v7-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc6_PM-v7-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc6_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc6_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hOc6_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hPO1_PM-v7-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hPO1_PM-v7-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-hPO1_PM-v7.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24ab_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24ab_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24ab_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24ab_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24ab_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24c_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24c_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24c_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p24c_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p24c_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p32_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p32_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p32_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-p32_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-p32_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s24_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s24_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s24_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s24_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s24_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s32_PM-v16-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s32_PM-v16-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s32_PM-v16-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-s32_PM-v16-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Area-s32_PM-v16.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_CA_PM-v11-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_CA_PM-v11-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_CA_PM-v11.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CA_PM-v11.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_CA_PM-v11-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_CA_PM-v11-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_CA_PM-v11.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_CA_PM-v11.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ch-123_PM-v4-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ch-123_PM-v4-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-123_PM-v4.2_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ch-4_PM-v4-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ch-4_PM-v4-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ch-4_PM-v4.2_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_DG_PM-v11-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_DG_PM-v11-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_DG_PM-v11.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_DG_PM-v11.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_DG_PM-v11-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_DG_PM-v11-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_DG_PM-v11.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_DG_PM-v11.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6-2_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6-2_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Dorsal-Dentate-Nucleus_PM-v6.2_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Entorhinal-Cortex_PM-v11-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Entorhinal-Cortex_PM-v11-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Entorhinal-Cortex_PM-v11-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Entorhinal-Cortex_PM-v11-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Entorhinal-Cortex_PM-v11.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Fastigial-Nucleus_PM-v6-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Fastigial-Nucleus_PM-v6-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Fastigial-Nucleus_PM-v6.2_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_HATA_PM-v11-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_HATA_PM-v11-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_HATA_PM-v11-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_HATA_PM-v11-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_HATA_PM-v11.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_IF_PM-v6-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_IF_PM-v6-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_IF_PM-v6.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_IF_PM-v6.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_IF_PM-v6-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_IF_PM-v6-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_IF_PM-v6.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_IF_PM-v6.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Interposed-Nucleus_PM-v6-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Interposed-Nucleus_PM-v6-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Interposed-Nucleus_PM-v6.2_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_MF_PM-v6-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_MF_PM-v6-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_MF_PM-v6.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_MF_PM-v6.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_MF_PM-v6-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_MF_PM-v6-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_MF_PM-v6.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_MF_PM-v6.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Subiculum_PM-v11-1_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Subiculum_PM-v11-1_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Subiculum_PM-v11-1_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Subiculum_PM-v11-1_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Subiculum_PM-v11.1_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_VTM_PM-v6-4_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_VTM_PM-v6-4_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_VTM_PM-v6-4_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_VTM_PM-v6-4_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_VTM_PM-v6.4_right"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6-2_left-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6-2_left-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_left"
     },

--- a/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6-2_right-jsonld.jsonld
+++ b/instances/atlas/serviceLink/JBA-v1-18/JBA-v1-18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6-2_right-jsonld.jsonld
@@ -3,7 +3,7 @@
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
     "@id": "https://openminds.ebrains.eu/instances/serviceLink/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right",
-    "@type": "https://openminds.ebrains.eu/core/serviceLink",
+    "@type": "https://openminds.ebrains.eu/core/ServiceLink",
     "dataLocation": {
         "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v1.18_Colin27-1998_Ventral-Dentate-Nucleus_PM-v6.2_right"
     },


### PR DESCRIPTION
@olinux please double check but both errors you discovered should now be fixed in all instances for JBA.

error at-type:
"https://openminds.ebrains.eu/core/serviceLink" instead of 
"https://openminds.ebrains.eu/core/ServiceLink"

error at-id for prop "hasVersion" in ParcellationEntities:
"https://openminds.ebrains.eu/instances/JBA-..." instead of
"https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-..."