### PR TITLE
fix typos WHSSD PE

### DIFF
--- a/instances/atlas/parcellationEntity/WHSSD/WHSSD_anteriorCommissure.jsonld
+++ b/instances/atlas/parcellationEntity/WHSSD/WHSSD_anteriorCommissure.jsonld
@@ -2,12 +2,12 @@
     "@context": {
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
-    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_anteriorCommisure",
+    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_anteriorCommissure",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
     "hasParent": null,
     "hasVersion": null,
-    "lookupLabel": "WHSSD_anteriorCommisure",
-    "name": "anterior commisure",
+    "lookupLabel": "WHSSD_anteriorCommissure",
+    "name": "anterior commissure",
     "ontologyIdentifier": null,
     "relatedUBERONTerm": null
 }

--- a/instances/atlas/parcellationEntity/WHSSD/WHSSD_corticofugalPathways.jsonld
+++ b/instances/atlas/parcellationEntity/WHSSD/WHSSD_corticofugalPathways.jsonld
@@ -2,12 +2,12 @@
     "@context": {
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
-    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_cortigofugalPathways",
+    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_corticofugalPathways",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
     "hasParent": null,
     "hasVersion": null,
-    "lookupLabel": "WHSSD_cortigofugalPathways",
-    "name": "cortigofugal pathways",
+    "lookupLabel": "WHSSD_corticofugalPathways",
+    "name": "corticofugal pathways",
     "ontologyIdentifier": null,
     "relatedUBERONTerm": null
 }

--- a/instances/atlas/parcellationEntity/WHSSD/WHSSD_mediodorsalNucleusOfTheDorsalThalamus.jsonld
+++ b/instances/atlas/parcellationEntity/WHSSD/WHSSD_mediodorsalNucleusOfTheDorsalThalamus.jsonld
@@ -2,12 +2,12 @@
     "@context": {
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
-    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_mediodorsalNucleusOfHeDorsalThalamus",
+    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_mediodorsalNucleusOfTheDorsalThalamus",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
     "hasParent": null,
     "hasVersion": null,
-    "lookupLabel": "WHSSD_mediodorsalNucleusOfHeDorsalThalamus",
-    "name": "mediodorsal nucleus of he dorsal thalamus",
+    "lookupLabel": "WHSSD_mediodorsalNucleusOfTheDorsalThalamus",
+    "name": "mediodorsal nucleus of the dorsal thalamus",
     "ontologyIdentifier": null,
     "relatedUBERONTerm": null
 }

--- a/instances/atlas/parcellationEntity/WHSSD/WHSSD_motorCortex.jsonld
+++ b/instances/atlas/parcellationEntity/WHSSD/WHSSD_motorCortex.jsonld
@@ -2,12 +2,12 @@
     "@context": {
         "@vocab": "https://openminds.ebrains.eu/vocab/"
     },
-    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_motorcortex",
+    "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/WHSSD_motorCortex",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
     "hasParent": null,
     "hasVersion": null,
-    "lookupLabel": "WHSSD_motorcortex",
-    "name": "motorcortex",
+    "lookupLabel": "WHSSD_motorCortex",
+    "name": "motor cortex",
     "ontologyIdentifier": null,
     "relatedUBERONTerm": null
 }


### PR DESCRIPTION
Fixed some typos in the names of the brain regions (and therefore also file names). This was causing issue when I was generating the parents of the PEV.

It would be great if this can be fixed, but let me know if this causes any issues downstream. 