### PR TITLE
increase semantic relationships for SANDS

### DIFF
--- a/schemas/miscellaneous/qualitativeRelationAssessment.schema.tpl.json
+++ b/schemas/miscellaneous/qualitativeRelationAssessment.schema.tpl.json
@@ -12,8 +12,10 @@
       ]
     },
     "inRelationTo": {
-      "_instruction": "Add the parcellation entity version to which the relation is described.",
+      "_instruction": "Add the custom or atlas parcellation entity (version) to which the relation is described.",
       "_linkedTypes": [
+        "https://openminds.ebrains.eu/sands/CustomAnatomicalEntity",
+        "https://openminds.ebrains.eu/sands/ParcellationEntity",
         "https://openminds.ebrains.eu/sands/ParcellationEntityVersion"
       ]
     },    


### PR DESCRIPTION
Originally we wanted to stick to PEVs to force proof of comparison (to a direct version).

For flexibility purposes I suggest to loosen this to build semantic relations also to PEs (if the version plays actually no role in the comparison/relation), and custom PEs (in case a relationship between custom PEs should be described).