### PR TITLE
changed over all PE parent to be consistent with DWMA

### DIFF
--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CAC-PoCi.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CAC-PoCi.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CAC-PrCu.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CAC-PrCu.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-Op.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-Op.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-PoC.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-PoC.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-PrC.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-PrC.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-RMF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-RMF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_CMF-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Cu-Li.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Cu-Li.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Fu-LO.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Fu-LO.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IC-PrCu.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IC-PrCu.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IP-IT.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IP-IT.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IP-LO.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IP-LO.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IP-MT.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IP-MT.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IP-SM.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IP-SM.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IP-SP.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IP-SP.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_IT-MT.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_IT-MT.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_LO-SP.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_LO-SP.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-MOF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-MOF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-Or.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-Or.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-RMF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-RMF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-ST.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_LOF-ST.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_MOF-ST.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_MOF-ST.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_MT-SM.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_MT-SM.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_MT-ST.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_MT-ST.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Op-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Op-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Op-PrC.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Op-PrC.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Op-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Op-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Op-Tr.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Op-Tr.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Or-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Or-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-PrC.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-PrC.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-SM.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-SM.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-SP.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoC-SP.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-PrCu.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-PrCu.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-RAC.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-RAC.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PoCi-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SM.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SM.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SP.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_PrC-SP.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_RAC-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_RAC-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_RMF-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_RMF-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_SM-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_SM-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_SP-SM.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_SP-SM.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_ST-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_ST-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_ST-TT.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_ST-TT.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Tr-Ins.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Tr-Ins.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_Tr-SF.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_Tr-SF.jsonld
@@ -6,7 +6,7 @@
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": [
     {
-      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles"
+      "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter"
     }
   ],
   "hasVersion": null,

--- a/instances/atlas/parcellationEntity/SWMA/SWMA_superficialWhiteMatter.jsonld
+++ b/instances/atlas/parcellationEntity/SWMA/SWMA_superficialWhiteMatter.jsonld
@@ -2,12 +2,12 @@
   "@context": {
     "@vocab": "https://openminds.ebrains.eu/vocab/"
   },
-  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialFibreBundles",
+  "@id": "https://openminds.ebrains.eu/instances/parcellationEntity/SWMA_superficialWhiteMatter",
   "@type": "https://openminds.ebrains.eu/sands/ParcellationEntity",
   "hasParent": null,
   "hasVersion": null,
-  "lookupLabel": "SWMA_superficialFibreBundles",
-  "name": "SWMA Superficial Fibre Bundles",
+  "lookupLabel": "SWMA_superficialWhiteMatter",
+  "name": "superficial white matter",
   "ontologyIdentifier": null,
   "relatedUBERONTerm": null
 }


### PR DESCRIPTION
@xgui3783 I've realized one inconsistency in the SWMA PEs in comparison to DWMA PEs:
Overall parent should be "superficial white matter" instead of "SWMA superficial fibre bundles". I've updated the PEs. 