### PR TITLE
adding annotation info to all PEVs of Area hOc1 (Julich-Brain Atlas)

### DIFF
--- a/instances/atlas/parcellationEntityVersion/JBA-v1-13/JBA-v1-13_Colin27-1998_Area-hOc1_PM-v2-2.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v1-13/JBA-v1-13_Colin27-1998_Area-hOc1_PM-v2-2.jsonld
@@ -12,7 +12,14 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.2/Area-hOc1_l_N10_nlin2Stdcolin27_2.2_publicP_85b208aaa47bf721c6d022a2283f3f60.nii.gz"
+			},
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.2/Area-hOc1_r_N10_nlin2Stdcolin27_2.2_publicP_cba07d46ec5ca1fa4b17383467f8737a.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
@@ -22,7 +29,9 @@
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/13/MPM/jubrain-max-pmap-v22c_space-mnicolin27.nii"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v1.13_Colin27-1998_Area-hOc1_PM-v2.2",

--- a/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2Stdcolin27_2.4_publicP_788fe1ea663b1fa4e7e9a8b5cf26c5d6.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/18/MPM/mpmatlas_l_N10_nlin2Stdcolin27_18_public_4720167a11fb4fe3b58b8bd9284a38a3.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2Stdcolin27_2.4_publicP_b3b742528b1d1a933c89b2604d23028d.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/18/MPM/mpmatlas_r_N10_nlin2Stdcolin27_18_public_2a35bda52754e9cc9d52945b661ca659.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v1.18_Colin27-1998_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2MNI152ASYM2009C_2.4_publicP_d3045ee3c0c4de9820eb1516d2cc72bb.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/18/MPM/mpmatlas_l_N10_nlin2icbm152casym_18_public_a5f6c95f2e7ff6f43b6bf7c816c37c8b.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v1-18/JBA-v1-18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2MNI152ASYM2009C_2.4_publicP_a48ca5d938781ebaf1eaa25f59df74d0.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/18/MPM/mpmatlas_r_N10_nlin2icbm152casym_18_public_9794c687d322d493f4cf67713349fc59.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v1.18_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2Stdcolin27_2.4_publicP_788fe1ea663b1fa4e7e9a8b5cf26c5d6.nii.gz"
+			}
+		],
         "internalIdentifier": "116",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/22/MPM/JulichBrain_MPMAtlas_l_N10_nlin2Stdcolin27_publicDOI_4514e5af7a15c96e47a049a98444ed7a.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2Stdcolin27_2.4_publicP_b3b742528b1d1a933c89b2604d23028d.nii.gz"
+			}
+		],
         "internalIdentifier": "116",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/22/MPM/JulichBrain_MPMAtlas_r_N10_nlin2Stdcolin27_publicDOI_862e709c1258b99106d936bbaccf0bdb.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.2_Colin27-1998_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2MNI152ASYM2009C_2.4_publicP_d3045ee3c0c4de9820eb1516d2cc72bb.nii.gz"
+			}
+		],
         "internalIdentifier": "116",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/22/MPM/JulichBrain_MPMAtlas_l_N10_nlin2Stdicbm152asym2009c_publicDOI_3f6407380a69007a54f5e13f3c1ba2e6.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-2/JBA-v2-2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2MNI152ASYM2009C_2.4_publicP_a48ca5d938781ebaf1eaa25f59df74d0.nii.gz"
+			}
+		],
         "internalIdentifier": "116",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/22/MPM/JulichBrain_MPMAtlas_r_N10_nlin2Stdicbm152asym2009c_publicDOI_14622b49a715338ce96e96611d395646.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.2_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_Colin27-1998_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
-        "internalIdentifier": "117",
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2Stdcolin27_2.4_publicP_788fe1ea663b1fa4e7e9a8b5cf26c5d6.nii.gz"
+			}
+		],
+		"internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/24/MPM/JulichBrain_MPMAtlas_l_N10_nlin2Stdcolin27_publicDOI_90c1619929d295ceac4b251de7e4e091.nii.gz"
+	    }
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_Colin27-1998_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2Stdcolin27_2.4_publicP_b3b742528b1d1a933c89b2604d23028d.nii.gz"
+			}
+		],
         "internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/24/MPM/JulichBrain_MPMAtlas_r_N10_nlin2Stdcolin27_publicDOI_0707d6b8ea66fa9f290279bb08842c92.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.4_Colin27-1998_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_l_N10_nlin2MNI152ASYM2009C_2.4_publicP_d3045ee3c0c4de9820eb1516d2cc72bb.nii.gz"
+			}
+		],
         "internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/24/MPM/JulichBrain_MPMAtlas_l_N10_nlin2Stdicbm152asym2009c_publicDOI_83fb39b2811305777db0eb80a0fc8b53.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-4/JBA-v2-4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2-4_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/2.4/Area-hOc1_r_N10_nlin2MNI152ASYM2009C_2.4_publicP_a48ca5d938781ebaf1eaa25f59df74d0.nii.gz"
+			}
+		],
         "internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/24/MPM/JulichBrain_MPMAtlas_r_N10_nlin2Stdicbm152asym2009c_publicDOI_172e93a5bec140c111ac862268f0d046.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.4_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v2.4_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_Colin27-1998_Area-hOc1_PM-v4-0_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_Colin27-1998_Area-hOc1_PM-v4-0_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_l_N10_nlin2Stdcolin27_4.0_publicP_298e7d4ceadf72bac05c519918b163c0.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/25/MPM/JuBrain_Map_colin_v25_l_c0d3d53168433f9a2db17d821f38f338.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_Colin27-1998_Area-hOc1_PM-v4-0_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_Colin27-1998_Area-hOc1_PM-v4-0_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_r_N10_nlin2Stdcolin27_4.0_publicP_5204cbbafc9465b9d5bb4285b1af0e3f.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/25/MPM/JuBrain_Map_colin_v25_r_2029036ffe1e728fb90d5f426631236b.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.5_Colin27-1998_Area-hOc1_PM-v4.0_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_l_N10_nlin2ICBM152asym2009c_4.0_publicP_f5279aa457d15d63fb420130e15fdbce.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/25/MPM/JuBrain_Map_icbm_v25_l_c12dc303cb4a3bb271646b6b65af0b54.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-5/JBA-v2-5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_r_N10_nlin2ICBM152asym2009c_4.0_publicP_f594e5c5e9b2f8cd1b3f31570acaacf9.nii.gz"
+			}
+		],
         "internalIdentifier": "120",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/25/MPM/JuBrain_Map_icbm_v25_r_a579dfcd53146ad2358259f437a47c00.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.5_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-6/JBA-v2-6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-6/JBA-v2-6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_left.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_l_N10_nlin2ICBM152asym2009c_4.0_publicP_f5279aa457d15d63fb420130e15fdbce.nii.gz"
+			}
+		],
         "internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/left"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/26/MPM/JulichBrain_MPMAtlas_l_N10_nlin2Stdicbm152asym2009c_publicDOI_3f5ec6016bc2242769c41befdbc1b2e0.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_left",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-6/JBA-v2-6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-6/JBA-v2-6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-0_right.jsonld
@@ -12,14 +12,20 @@
             "@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
         },
         "displayColor": "#be8493",
-        "inspiredBy": null,
+        "inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.0/Area-hOc1_r_N10_nlin2ICBM152asym2009c_4.0_publicP_f594e5c5e9b2f8cd1b3f31570acaacf9.nii.gz"
+			}
+		],
         "internalIdentifier": "117",
         "laterality": [
             {
                 "@id": "https://openminds.ebrains.eu/instances/laterality/right"
             }
         ],
-        "visualizedIn": null
+        "visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/26/MPM/JulichBrain_MPMAtlas_r_N10_nlin2Stdicbm152asym2009c_publicDOI_453c4c95827e38dcce5372b200065cba.nii.gz"
+		}
     },
     "hasParent": null,
     "lookupLabel": "JBA-v2.6_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.0_right",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_Colin27-1998_Area-hOc1_PM-v4-2_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_Colin27-1998_Area-hOc1_PM-v4-2_left.jsonld
@@ -4,7 +4,29 @@
     },
     "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hOc1_PM-v4.2_left",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
-    "hasAnnotation": null,
+    "hasAnnotation": {
+		"@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+        "bestViewPoint": null,
+        "criteria": null,
+		"criteriaQualityType": {
+			"@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+		},
+		"displayColor": "#be8493",
+		"inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.2/Area-hOc1_l_N10_nlin2Stdcolin27_4.2_publicP_026bcbe494dc4bfe702f2b1cc927a7c1.nii.gz"
+			}
+		],
+		"internalIdentifier": "8",
+		"laterality": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/laterality/left"
+			}
+		],
+		"visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/29/MPMs/GapMapPublicMPMAtlas_l_N10_nlin2StdColin27_29_publicDOI_7f7bae194464eb71431c9916614d5f89.nii.gz"
+		}
+	},
     "hasParent": null,
     "lookupLabel": "JBA-v2.9_Colin27-1998_Area-hOc1_PM-v4.2_left",
     "name": "Area hOc1 (V1, 17, CalcS)",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_Colin27-1998_Area-hOc1_PM-v4-2_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_Colin27-1998_Area-hOc1_PM-v4-2_right.jsonld
@@ -4,7 +4,29 @@
     },
     "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_Colin27-1998_Area-hOc1_PM-v4.2_right",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
-    "hasAnnotation": null,
+    "hasAnnotation": {
+		"@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+		"bestViewPoint": null,
+        "criteria": null,
+		"criteriaQualityType": {
+			"@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+		},
+		"displayColor": "#be8493",
+		"inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.2/Area-hOc1_r_N10_nlin2Stdcolin27_4.2_publicP_d8d7a22f9ea3b0fbd6f983c15697d834.nii.gz"
+			}
+		],
+		"internalIdentifier": "8",
+		"laterality": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/laterality/right"
+			}
+		],
+		"visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/29/MPMs/GapMapPublicMPMAtlas_r_N10_nlin2StdColin27_29_publicDOI_883290e4569b289d35e78decdbc5deb7.nii.gz"
+		}
+	},
     "hasParent": null,
     "lookupLabel": "JBA-v2.9_Colin27-1998_Area-hOc1_PM-v4.2_right",
     "name": "Area hOc1 (V1, 17, CalcS)",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-2_left.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-2_left.jsonld
@@ -4,7 +4,29 @@
     },
     "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.2_left",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
-    "hasAnnotation": null,
+    "hasAnnotation": {
+		"@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+        "bestViewPoint": null,
+        "criteria": null,
+		"criteriaQualityType": {
+			"@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+		},
+		"displayColor": "#be8493",
+		"inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.2/Area-hOc1_l_N10_nlin2ICBM152asym2009c_4.2_publicP_026bcbe494dc4bfe702f2b1cc927a7c1.nii.gz"
+			}
+		],
+		"internalIdentifier": "8",
+		"laterality": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/laterality/left"
+			}
+		],
+		"visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/29/MPMs/GapMapPublicMPMAtlas_l_N10_nlin2StdICBM152asym2009c_29_publicDOI_b1bcc0b5a127f5a917f0d8b0e869be5d.nii.gz"
+		}
+	},
     "hasParent": null,
     "lookupLabel": "JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.2_left",
     "name": "Area hOc1 (V1, 17, CalcS)",

--- a/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-2_right.jsonld
+++ b/instances/atlas/parcellationEntityVersion/JBA-v2-9/JBA-v2-9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4-2_right.jsonld
@@ -4,7 +4,29 @@
     },
     "@id": "https://openminds.ebrains.eu/instances/parcellationEntityVersion/JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.2_right",
     "@type": "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
-    "hasAnnotation": null,
+    "hasAnnotation": {
+		"@type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
+        "bestViewPoint": null,
+        "criteria": null,
+		"criteriaQualityType": {
+			"@id": "https://openminds.ebrains.eu/instances/criteriaQualityType/processive"
+		},
+		"displayColor": "#be8493",
+		"inspiredBy": [
+			{
+				"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas-Area-hOc1_pub/4.2/Area-hOc1_r_N10_nlin2ICBM152asym2009c_4.2_publicP_d8d7a22f9ea3b0fbd6f983c15697d834.nii.gz"
+			}
+		],
+		"internalIdentifier": "8",
+		"laterality": [
+			{
+				"@id": "https://openminds.ebrains.eu/instances/laterality/right"
+			}
+		],
+		"visualizedIn": {
+			"@id": "https://object.cscs.ch/v1/AUTH_227176556f3c4bb38df9feea4b91200c/hbp-d000001_jubrain-cytoatlas_pub/29/MPMs/GapMapPublicMPMAtlas_r_N10_nlin2StdICBM152asym2009c_29_publicDOI_57517b0a8dedb2ef53a661d40404e206.nii.gz"
+		}
+	},
     "hasParent": null,
     "lookupLabel": "JBA-v2.9_MNI-ICBM-152-2009c-nonlin-asym_Area-hOc1_PM-v4.2_right",
     "name": "Area hOc1 (V1, 17, CalcS)",


### PR DESCRIPTION
@xgui3783 I will merge this PR without review so that Oli has the test cases for tomorrow. We soon need to complete the annotation info for all PEVs of the Julich-Brain.

@olinux this PR adds nearly all annotation info to all PEVs for Julich-Brain Area hOc1 (PE uuid in KG: 9f478e0a-3b2d-4324-a817-cc22f73acdc6)