### PR TITLE
Fix "_formats" for "ontology" property in BrainAtlas and BrainAtlasVersion

### DIFF
--- a/schemas/atlas/brainAtlas.schema.tpl.json
+++ b/schemas/atlas/brainAtlas.schema.tpl.json
@@ -45,7 +45,9 @@
     "ontologyIdentifier": {
       "type": "string",
       "_instruction": "Enter the identifier (IRI) of the related ontological term matching this brain atlas.",
-      "_formats": "iri"
+      "_formats": [
+        "iri"
+      ]
     }
   }
 }

--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -70,7 +70,9 @@
     "ontologyIdentifier": {
       "type": "string",
       "_instruction": "Enter the identifier (IRI) of the related ontological term matching this brain atlas version.",
-      "_formats": "iri"
+      "_formats": [
+        "iri"
+      ]
     },
     "usedSpecimen": {
       "type": "array",


### PR DESCRIPTION
For all other schemas/properties, "_formats" contains a list