### PR TITLE
Clean up: anatomical target position

### DIFF
--- a/schemas/miscellaneous/anatomicalTargetPosition.schema.tpl.json
+++ b/schemas/miscellaneous/anatomicalTargetPosition.schema.tpl.json
@@ -1,41 +1,37 @@
 {
-    "_type": "https://openminds.ebrains.eu/sands/AnatomicalTargetPosition",
-    "required": [
-        "anatomicalTarget",
-        "targetIdentificationType"
-    ],
-    "properties": {
-        "anatomicalTarget": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true,
-            "_instruction": "Add the anatomical target(s) for this position.",
-            "_linkedTypes": [
-                "https://openminds.ebrains.eu/sands/ParcellationEntity",
-                "https://openminds.ebrains.eu/sands/ParcellationEntityVersion",
-                "https://openminds.ebrains.eu/sands/CustomAnatomicalEntity",
-                "https://openminds.ebrains.eu/controlledTerms/OrganismSubstance",
-                "https://openminds.ebrains.eu/controlledTerms/CellType",
-                "https://openminds.ebrains.eu/controlledTerms/Organ",
-                "https://openminds.ebrains.eu/controlledTerms/SubcellularEntity",
-                "https://openminds.ebrains.eu/controlledTerms/UBERONParcellation"
-            ]
-        },
-        "targetIdentificationType": {
-            "_instruction": "Add the target identification type used to get to this anatomical position.",
-            "_linkedTypes": [
-                "https://openminds.ebrains.eu/controlledTerms/AnatomicalIdentificationType"
-            ]
-        },
-        "coordinates": {
-            "_instruction": "If possible, add the coordinates that best represent this anatomical position.",
-            "_embeddedTypes": [
-                "https://openminds.ebrains.eu/sands/CoordinatePoint"
-            ]
-        },
-        "additionalRemarks": {
-            "type": "string",
-            "_instruction": "Enter any additional remarks that are needed to interpret the properties of this anatomical target position (e.g., what exatly the coordinates represent: central position, bottom, left corner edge, etc)."
-        }
+  "_type": "https://openminds.ebrains.eu/sands/AnatomicalTargetPosition",
+  "required": [
+    "anatomicalTarget",
+    "targetIdentificationType"
+  ],
+  "properties": {
+    "additionalRemarks": {
+      "type": "string",
+      "_instruction": "Enter any additional remarks concering this anatomical target position."
+    },
+    "anatomicalTarget": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all anatomical entities that describe the target position(s).",
+      "_linkedCategories": [
+        "anatomicalLocation"
+      ]
+    },    
+    "spatialLocation": {      
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "_instruction": "Add all coordinate points that describe the spatial location of the anatomical target structure(s).",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/sands/CoordinatePoint"
+      ]
+    },
+    "targetIdentificationType": {
+      "_instruction": "Add the target identification type that best describes how the this anatomical target position was identified.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/AnatomicalIdentificationType"
+      ]
     }
+  }
 }


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- establish alphabetical order
- fix indentation
- `anatomicalTarget` links to new category `anatomicalLocation` which holds all the same schemas
- replaced `coordinates` by `anchorPoint` to avoid confusions with other coordinates and because it fits better, especially since several points are allowed now

MAJOR changes:
none

SPECIAL ATTENTION:
- `anchorPoint` allows 0 - N values instead of 0 - 1 since this might be required to describe the target (necessary because `devicePlacement` schema only allows 1 `targetPosition`; could be changed there, but thought it would make more sense here:
     - several anatomicalTargets allowed, so one coordinatePoint would not be able to describe this 
     - BUT several anatomicalTargets are important to keep to be able to describe the target properly 
  