### PR TITLE
Clean up: brain atlas version

### DIFF
--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -21,7 +21,7 @@
       ]
     },  
     "coordinateSpace": {
-      "_instruction": "Add the common coordinate space version in which this brain atlas version exists in.",
+      "_instruction": "Add the specific common coordinate space in which this brain atlas version exists.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
       ]
@@ -35,7 +35,7 @@
       ]
     },
     "hasTerminology": {
-      "_instruction": "Enter the parcellation terminology version of this brain atlas version.",
+      "_instruction": "Enter the specific parcellation terminology of this brain atlas version.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion"
       ]

--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -3,7 +3,7 @@
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
   "required": [
     "coordinateSpace",
-    "hasTerminologyVersion",
+    "hasTerminology",
     "license"
   ],
   "properties": {
@@ -11,17 +11,11 @@
       "type": "string",
       "_instruction": "Enter the official abbreviation of this brain atlas version."
     },
-    "atlasType": {
-      "_instruction": "Add the type of this brain atlas version.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/controlledTerms/AtlasType"
-      ]
-    },   
     "author": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "If necessary, add one or several authors (person or organization) that contributed to the production and publication of this brain atlas version. Note that these authors will overwrite the once provided in the brain atlas product this version belongs to.",
+      "_instruction": "Add all parties that contributed to this brain atlas version as authors. Note that these authors will overwrite the author list provided for the overarching brain atlas.",
       "_linkedCategories": [
         "legalPerson"
       ]
@@ -33,15 +27,15 @@
       ]
     },
     "digitalIdentifier": {
-      "_instruction": "Add the globally unique and persistent digital identifier of this brain atlas version.",
+      "_instruction": "Add the globally unique and persistent digital identifier of this research product version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/DOI",
         "https://openminds.ebrains.eu/core/ISBN",
         "https://openminds.ebrains.eu/core/RRID"
       ]
     },
-    "hasTerminologyVersion": {
-      "_instruction": "Add the parcellation terminology version for this brain atlas version.",
+    "hasTerminology": {
+      "_instruction": "Enter the parcellation terminology version of this brain atlas version.",
       "_embeddedTypes": [
         "https://openminds.ebrains.eu/sands/ParcellationTerminologyVersion"
       ]
@@ -50,35 +44,41 @@
       "type": "array",      
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or several alternative versions to this brain atlas version.",
+      "_instruction": "Add all brain atlas versions that can be used alternatively to this brain atlas version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/BrainAtlasVersion"
       ]
     },
     "isNewVersionOf": {
-      "_instruction": "Add the earlier version of this brain atlas version.",
+      "_instruction": "Add brain atlas version preceding this brain atlas version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/BrainAtlasVersion"
       ]
     },    
     "license": {
-      "_instruction": "Add the license for this brain atlas version.",
+      "_instruction": "Add the license of this brain atlas version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/License"
       ]
     },
     "ontologyIdentifier": {
       "type": "string",
-      "_instruction": "Enter the identifier (IRI) of the related ontological term matching this brain atlas version.",
+      "_instruction": "Enter the internationalized resource identifier (IRI) to the related ontological term matching this brain atlas version.",
       "_formats": [
         "iri"
       ]
-    },
+    },    
+    "type": {
+      "_instruction": "Add the type of this brain atlas version.",
+      "_linkedTypes": [
+        "https://openminds.ebrains.eu/controlledTerms/AtlasType"
+      ]
+    },   
     "usedSpecimen": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
-      "_instruction": "Add one or several specimen (subjects and/or tissue samples) or specimen sets (subject groups and/or tissue sample collections) that were used to create this atlas version.",
+      "_instruction": "Add the specimen that was used for the creation of this brain atlas version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/core/Subject",
         "https://openminds.ebrains.eu/core/SubjectGroup",

--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -50,7 +50,7 @@
       ]
     },
     "isNewVersionOf": {
-      "_instruction": "Add brain atlas version preceding this brain atlas version.",
+      "_instruction": "Add the brain atlas version preceding this brain atlas version.",
       "_linkedTypes": [
         "https://openminds.ebrains.eu/sands/BrainAtlasVersion"
       ]


### PR DESCRIPTION
MINOR changes:
- improved instructions 
- renamed `atlasType` to `type` to reduce list of properties & because of new convention to use type when the additional information is not adding any other meaning than imposed by schema already 
- renamed `hasTerminologyVersion` to `hasTerminology` to reduce list of property names and follow new convention to not add "version" to an existing property name (no need to differentiate since the expected values are limited to versions)

MAJOR changes:
none

SPECIAL ATTENTION:
none
