### PR TITLE
add "majorVersionIdentifier" to brainAtlasVersion.schema.tpl.json

### DIFF
--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -61,6 +61,10 @@
         "https://openminds.ebrains.eu/core/License"
       ]
     },
+    "majorVersionIdentifier": {
+      "type": "string",
+      "_instruction": "Enter the identifier of the major version release this research product version belongs to."
+    },
     "ontologyIdentifier": {
       "type": "string",
       "_instruction": "Enter the internationalized resource identifier (IRI) to the related ontological term matching this brain atlas version.",


### PR DESCRIPTION
Something we discussed a while ago. 

This will make it easier to identify alternative versions that belong to the same major release (even though this is still connected with curation effort for keeping consistency).