### PR TITLE
anchorPoint update

### DIFF
--- a/schemas/atlas/annotation.schema.tpl.json
+++ b/schemas/atlas/annotation.schema.tpl.json
@@ -4,13 +4,7 @@
     "criteriaType",
     "type"
   ],
-  "properties": {       
-    "anchorPoint": {
-      "_instruction": "Enter the anchor point for this annotation (e.g., its centroid).",
-      "_embeddedTypes": [
-      "https://openminds.ebrains.eu/sands/CoordinatePoint"
-      ]
-    },    
+  "properties": {
     "criteria": {
       "_instruction": "Add the protocol execution defining the criteria that were applied to produce this annotation.",
       "_linkedTypes": [

--- a/schemas/atlas/annotation.schema.tpl.json
+++ b/schemas/atlas/annotation.schema.tpl.json
@@ -5,6 +5,15 @@
     "type"
   ],
   "properties": {
+    "anchorPoint": {
+      "type": "array",      
+      "minItems": 2,
+      "maxItems": 3,
+      "_instruction": "Enter the coordinates of the anchor point for this annotation (e.g., its centroid in two dimensional space as [x, y] or in three dimensional space as [x, y, z]).",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/core/QuantitativeValue"
+      ]
+    },
     "criteria": {
       "_instruction": "Add the protocol execution defining the criteria that were applied to produce this annotation.",
       "_linkedTypes": [

--- a/schemas/atlas/atlasAnnotation.schema.tpl.json
+++ b/schemas/atlas/atlasAnnotation.schema.tpl.json
@@ -1,16 +1,7 @@
 {
   "_type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
   "_extends": "atlas/annotation.schema.tpl.json",
-  "properties": {   
-    "anchorPoint": {
-      "type": "array",      
-      "minItems": 2,
-      "maxItems": 3,
-      "_instruction": "Enter the coordinates of the anchor point for this annotation (e.g., its centroid in two dimensional space as [x, y] or in three dimensional space as [x, y, z]).",
-      "_embeddedTypes": [
-        "https://openminds.ebrains.eu/core/QuantitativeValue"
-      ]
-    },
+  "properties": {
     "specification": {
       "_instruction": "Add the non-parametric specification of this annotation.",
       "_linkedTypes": [

--- a/schemas/atlas/atlasAnnotation.schema.tpl.json
+++ b/schemas/atlas/atlasAnnotation.schema.tpl.json
@@ -1,14 +1,14 @@
 {
   "_type": "https://openminds.ebrains.eu/sands/AtlasAnnotation",
   "_extends": "atlas/annotation.schema.tpl.json",
-  "required": [
-    "coordinateSpace"
-  ],
   "properties": {   
-    "coordinateSpace": {
-      "_instruction": "Add the common coordinate space version for this annotation.",
-      "_linkedTypes": [
-        "https://openminds.ebrains.eu/sands/CommonCoordinateSpaceVersion"
+    "anchorPoint": {
+      "type": "array",      
+      "minItems": 2,
+      "maxItems": 3,
+      "_instruction": "Enter the coordinates of the anchor point for this annotation (e.g., its centroid in two dimensional space as [x, y] or in three dimensional space as [x, y, z]).",
+      "_embeddedTypes": [
+        "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]
     },
     "specification": {

--- a/schemas/miscellaneous/viewerSpecification.schema.tpl.json
+++ b/schemas/miscellaneous/viewerSpecification.schema.tpl.json
@@ -9,9 +9,12 @@
       "_instruction": "Enter any additional remarks concerning this viewer specification."
     },
     "anchorPoint": {
-      "_instruction": "Enter the anchor point that a viewer should use. Either state the anchor point of the annotation again or state another coordinate point.",
+      "type": "array",      
+      "minItems": 2,
+      "maxItems": 3,
+      "_instruction": "Enter the coordinates of the anchor point that a viewer should use. Either state the anchor point of the annotation again or state another coordinate point.",
       "_embeddedTypes": [
-        "https://openminds.ebrains.eu/sands/CoordinatePoint"
+        "https://openminds.ebrains.eu/core/QuantitativeValue"
       ]
     },
     "cameraPosition": {

--- a/schemas/non-atlas/customAnnotation.schema.tpl.json
+++ b/schemas/non-atlas/customAnnotation.schema.tpl.json
@@ -4,7 +4,7 @@
   "required": [
     "coordinateSpace"
   ],
-  "properties": {   
+  "properties": {
     "coordinateSpace": {
       "_instruction": "Add the coordinate space for this custom annotation.",
       "_linkedTypes": [


### PR DESCRIPTION
all atlas entities do not need to state a coordinate point with space, because the space is already known.