### PR TITLE
Make license optional for BrainAtlasVersion

### DIFF
--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -3,8 +3,7 @@
   "_extends": "/core/schemas/products/researchProductVersion.schema.tpl.json",
   "required": [
     "coordinateSpace",
-    "hasTerminology",
-    "license"
+    "hasTerminology"
   ],
   "properties": {
     "abbreviation": {


### PR DESCRIPTION
This is needed to make it possible to reigster the Paxinos and Watson atlas. It has a copyright, so it does not have a license.