### PR TITLE
switch connection between RP and RPVs

### DIFF
--- a/schemas/atlas/brainAtlas.schema.tpl.json
+++ b/schemas/atlas/brainAtlas.schema.tpl.json
@@ -26,27 +26,18 @@
         "core:ISBN",
         "core:RRID"
       ]
-    },    
+    },
     "hasTerminology": {
       "_instruction": "Enter the parcellation terminology of this brain atlas.",
       "_embeddedTypes": [
         "sands:ParcellationTerminology"
       ]
     },
-    "hasVersion": {
-      "type": "array",      
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add versions of this brain atlas.",
-      "_linkedTypes": [
-        "sands:BrainAtlasVersion"
-      ]
-    },
     "ontologyIdentifier": {
       "type": "string",
       "_formats": [
         "iri"
-      ],      
+      ],
       "_instruction": "Enter the internationalized resource identifier (IRI) to the related ontological term matching this brain atlas."
     },
     "usedSpecies": {

--- a/schemas/atlas/brainAtlasVersion.schema.tpl.json
+++ b/schemas/atlas/brainAtlasVersion.schema.tpl.json
@@ -19,7 +19,7 @@
       "_linkedCategories": [
         "legalPerson"
       ]
-    },  
+    },
     "coordinateSpace": {
       "_instruction": "Add the specific common coordinate space in which this brain atlas version exists.",
       "_linkedTypes": [
@@ -40,8 +40,14 @@
         "sands:ParcellationTerminologyVersion"
       ]
     },
-    "isAlternativeVersionOf": {
-      "type": "array",      
+    "isPrecededBy": {
+      "_instruction": "Add the brain atlas version preceding this brain atlas version.",
+      "_linkedTypes": [
+        "sands:BrainAtlasVersion"
+      ]
+    },
+    "isVariantOf": {
+      "type": "array",
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Add all brain atlas versions that can be used alternatively to this brain atlas version.",
@@ -49,12 +55,12 @@
         "sands:BrainAtlasVersion"
       ]
     },
-    "isNewVersionOf": {
-      "_instruction": "Add the brain atlas version preceding this brain atlas version.",
+    "isVersionOf": {
+      "_instruction": "Add the version-independent information about this brain atlas.",
       "_linkedTypes": [
-        "sands:BrainAtlasVersion"
+        "sands:BrainAtlas"
       ]
-    },    
+    },
     "license": {
       "_instruction": "Add the license of this brain atlas version.",
       "_linkedTypes": [
@@ -71,13 +77,13 @@
       "_formats": [
         "iri"
       ]
-    },    
+    },
     "type": {
       "_instruction": "Add the type of this brain atlas version.",
       "_linkedTypes": [
         "controlledTerms:AtlasType"
       ]
-    },   
+    },
     "usedSpecimen": {
       "type": "array",
       "minItems": 1,

--- a/schemas/atlas/commonCoordinateSpace.schema.tpl.json
+++ b/schemas/atlas/commonCoordinateSpace.schema.tpl.json
@@ -29,24 +29,15 @@
         "core:RRID"
       ]
     },
-    "hasVersion": {
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "_instruction": "Add all versions of this common coordinate space.",
-      "_linkedTypes": [
-        "sands:CommonCoordinateSpaceVersion"
-      ]
-    },
     "ontologyIdentifier": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Enter the internationalized resource identifiers (IRIs) to the related ontological terms matching this common coordinate space.",
-      "items": {        
+      "items": {
         "type": "string",
         "_formats": [
-          "iri"        
+          "iri"
         ]
       }
     },

--- a/schemas/atlas/commonCoordinateSpaceVersion.schema.tpl.json
+++ b/schemas/atlas/commonCoordinateSpaceVersion.schema.tpl.json
@@ -5,7 +5,7 @@
     "coordinateSpace"
   ],
   "required": [
-    "anatomicalAxesOrientation",   
+    "anatomicalAxesOrientation",
     "axesOrigin",
     "nativeUnit"
   ],
@@ -30,9 +30,9 @@
       ]
     },
     "axesOrigin": {
-      "type": "array",        
-      "minItems": 2,      
-      "maxItems": 3,    
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 3,
       "uniqueItems": true,
       "_instruction": "Enter the origin (central point where all axes intersect) of this common coordinate space version for two-dimensional spaces as [x, y] or for three-dimensional space as [x, y, z].",
       "_embeddedTypes": [
@@ -40,7 +40,7 @@
       ]
     },
     "defaultImage": {
-      "type": "array",      
+      "type": "array",
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Add all image files used as visual representation of this common coordinate space version.",
@@ -56,7 +56,13 @@
         "core:RRID"
       ]
     },
-    "isAlternativeVersionOf": {
+    "isPrecededBy": {
+      "_instruction": "Add the common coordinate space version preceding this common coordinate space version.",
+      "_linkedTypes": [
+        "sands:CommonCoordinateSpaceVersion"
+      ]
+    },
+    "isVariantOf": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
@@ -65,10 +71,10 @@
         "sands:CommonCoordinateSpaceVersion"
       ]
     },
-    "isNewVersionOf": {
-      "_instruction": "Add the common coordinate space version preceding this common coordinate space version.",
+    "isVersionOf": {
+      "_instruction": "Add the version-independent information about this common coordinate space.",
       "_linkedTypes": [
-        "sands:CommonCoordinateSpaceVersion"
+        "sands:CommonCoordinateSpace"
       ]
     },
     "license": {
@@ -82,16 +88,16 @@
       "_linkedTypes": [
         "controlledTerms:UnitOfMeasurement"
       ]
-    },    
+    },
     "ontologyIdentifier": {
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,
       "_instruction": "Enter the internationalized resource identifiers (IRIs) to the related ontological terms matching this common coordinate space version.",
-      "items": {       
+      "items": {
         "type": "string",
         "_formats": [
-          "iri"        
+          "iri"
         ]
       }
     },


### PR DESCRIPTION
RPVs now refer to their parent RP with isVersionOf. We remove hasVersion from the RP.

Related to https://github.com/openMetadataInitiative/openMINDS_core/pull/553