### PR TITLE
Fix type number

### DIFF
--- a/schemas/mathematicalShape/frustum.schema.tpl.json
+++ b/schemas/mathematicalShape/frustum.schema.tpl.json
@@ -23,7 +23,7 @@
       ]
     },
     "minorBaseScale": {
-      "type": "float",      
+      "type": "number",      
       "exclusiveMinimum": 0,
       "exclusiveMaximum": 1,
       "_instruction": "Enter the ratio of the smaller to the larger base size of this frustum."


### PR DESCRIPTION
Float is not a valid type in JSON Schema. We should use number instead.