### PR TITLE
Rename 'versionInnovation' to 'versionSpecification'

### DIFF
--- a/schemas/atlas/parcellationEntityVersion.schema.tpl.json
+++ b/schemas/atlas/parcellationEntityVersion.schema.tpl.json
@@ -91,7 +91,7 @@
       "type": "string",
       "_instruction": "Enter the version identifier of this parcellation entity version."
     },
-    "versionInnovation": {
+    "versionSpecification": {
       "type": "string",
       "_instruction": "Enter a short description (or summary) of the novelties/peculiarities of this parcellation entity version in comparison to its preceding versions. If this parcellation entity version is the first version, leave blank."
     }


### PR DESCRIPTION
Aligns parcellationEntityVersion with the changes introduced in openMINDS v5 to RPVs.
Fix #316 
Instances will need to be updated.